### PR TITLE
Опечатка в имени класса - от RM, а не от RME

### DIFF
--- a/layouts/radicalmart_express/order/create.php
+++ b/layouts/radicalmart_express/order/create.php
@@ -11,7 +11,7 @@
 
 defined('_JEXEC') or die;
 
-echo \Joomla\Component\RadicalMart\Administrator\Helper\LayoutsHelper::renderSiteLayout(
+echo \Joomla\Component\RadicalMartExpress\Administrator\Helper\LayoutsHelper::renderSiteLayout(
 	'plugins.radicalmart_message.email.radicalmart_express.order.change_status',
 	$displayData
 );


### PR DESCRIPTION
Исправлено, а то при создании заказа валилась ошибка. Заказ создавался, а далее не шло